### PR TITLE
Query Changes

### DIFF
--- a/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
@@ -44,6 +44,9 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "metrics", defaultValue = "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne,io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo,io.sease.rre.core.domain.metrics.impl.PrecisionAtThree,io.sease.rre.core.domain.metrics.impl.PrecisionAtTen")
     private List<String> metrics;
 
+    @Parameter(name = "plugins")
+    private List<String> plugins;
+
     @Parameter(name = "fields", defaultValue = "")
     private String fields;
 
@@ -87,7 +90,13 @@ public class RREvaluateMojo extends AbstractMojo {
                     null,
                     persistence);
 
-            final Map<String, Object> configuration = Collections.emptyMap();
+            final Map<String, Object> configuration = new HashMap<>();
+            // Most of these don't actually apply except for plugins, but the class ExternalElastic extends expects them
+            configuration.put("path.home", "/tmp");
+            configuration.put("path.data", "target/tmp");
+            configuration.put("network.host", 9200);
+            configuration.put("plugins", plugins);
+            configuration.put("forceRefresh", false);
 
             write(engine.evaluate(configuration));
         } catch (final IOException exception) {

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/ExternalElasticsearch.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/ExternalElasticsearch.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.settings.Settings;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,7 +38,8 @@ public class ExternalElasticsearch extends Elasticsearch {
 
     @Override
     public void beforeStart(Map<String, Object> configuration) {
-        // No-op for this implementation
+        // Need RRE node instantiated to get plugin info (This does not start the node)
+        super.beforeStart(configuration);
     }
 
     @Override


### PR DESCRIPTION
This uses XContentParser to parse queries which adds compatibility for things like rescore and verifying the internals of an LTR query.

It does add some headache if you just want to get things working using an external instance, it requires that the plugins be installed local to RRE and configured in the pom file.  I'm still weighing whether or not this is a good change for external, it makes sense for the internal engine. 

Any thoughts?  The alternative was to add another block that just parsed out a rescore object but I felt like there may be other plugins I have no idea about utilizing other keys.

